### PR TITLE
Fix SLURM manager and add SSH tunneling

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - py-cpuinfo
     - jupyter
     - seaborn
+    - sshtunnel
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - anaconda-client=1.7.2=py_0
   - ansimarkup=1.4.0=py_0
   - ansiwrap=0.8.4=py_0
   - appnope=0.1.0=py37_1000
@@ -13,6 +14,8 @@ dependencies:
   - backports=1.0=py_2
   - backports.tempfile=1.0=py_0
   - backports.weakref=1.0.post1=py37_1000
+  - bcrypt=3.1.6=py37h01d97ff_1
+  - beautifulsoup4=4.7.1=py37_1001
   - better_exceptions_fork=0.2.1.post6=py_0
   - bleach=3.1.0=py_0
   - bzip2=1.0.6=h1de35cc_1002
@@ -21,37 +24,67 @@ dependencies:
   - cffi=1.12.3=py37hccf1714_0
   - chardet=3.0.4=py37_1003
   - click=7.0=py_0
+  - clyent=1.2.2=py_1
   - colorama=0.4.1=py_0
+  - conda=4.6.14=py37_0
+  - conda-build=3.18.1=py37_0
+  - conda-package-handling=1.1.5=py37_0
+  - conda-verify=3.1.1=py37_1000
   - cryptography=2.6.1=py37h212c5bf_0
+  - cycler=0.10.0=py_1
+  - dbus=1.13.6=h2f22bb5_0
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py37_1000
+  - expat=2.2.5=h0a44026_1002
+  - filelock=3.0.10=py_0
+  - freetype=2.10.0=h24853df_0
   - future=0.17.1=py37_1000
+  - gettext=0.19.8.1=h46ab8bc_1002
   - gevent=1.4.0=py37h470a237_0
+  - glib=2.58.3=h2836805_1001
+  - glob2=0.6=py_0
   - greenlet=0.4.15=py37h01d97ff_0
+  - icu=58.2=h0a44026_1000
   - idna=2.8=py37_1000
+  - ipykernel=5.1.1=py37h24bf2e0_0
   - ipython=7.5.0=py37h24bf2e0_0
   - ipython_genutils=0.2.0=py_1
+  - ipywidgets=7.4.2=py_0
   - jedi=0.13.3=py37_0
   - jinja2=2.10.1=py_0
+  - jpeg=9c=h1de35cc_1001
   - jsonschema=3.0.1=py37_0
+  - jupyter=1.0.0=py_2
   - jupyter_client=5.2.4=py_3
+  - jupyter_console=6.0.0=py_0
   - jupyter_core=4.4.0=py_0
+  - kiwisolver=1.1.0=py37h770b8ee_0
+  - leveldb=1.18=0
+  - libarchive=3.3.3=h46c8594_1004
   - libblas=3.8.0=10_openblas
   - libcblas=3.8.0=10_openblas
   - libcxx=8.0.0=2
   - libcxxabi=8.0.0=2
   - libffi=3.2.1=h6de7cb9_1006
   - libgfortran=3.0.1=0
+  - libiconv=1.15=h01d97ff_1005
   - liblapack=3.8.0=10_openblas
+  - liblief=0.9.0=h2a1bed3_1
+  - libpng=1.6.37=h2573ce8_0
   - libsodium=1.0.16=h1de35cc_1001
+  - libxml2=2.9.9=hd80cff7_0
   - loguru=0.2.5=py_0
+  - lz4-c=1.8.3=h6de7cb9_1001
+  - lzo=2.10=h1de35cc_1000
   - markupsafe=1.1.1=py37h1de35cc_0
+  - matplotlib-base=3.1.0=py37h3a684a6_1
   - mistune=0.8.4=py37h1de35cc_1000
   - msgpack-python=0.6.1=py37h04f5b5a_0
   - nbconvert=5.5.0=py_0
   - nbformat=4.4.0=py_1
   - ncurses=6.1=h0a44026_1002
+  - notebook=5.7.8=py37_1
   - numpy=1.16.3=py37hdf140aa_0
   - openblas=0.3.6=hd44dcd8_2
   - openssl=1.1.1b=h01d97ff_2
@@ -59,36 +92,60 @@ dependencies:
   - pandoc=2.7.2=0
   - pandocfilters=1.4.2=py_1
   - papermill=1.0.0=py37_0
+  - paramiko=2.5.0=py37_0
   - parso=0.4.0=py_0
   - pathspec=0.5.9=py_0
+  - patsy=0.5.1=py_0
+  - pcre=8.41=h0a44026_1003
   - peewee=3.9.2=py37hb402a30_0
   - pexpect=4.7.0=py37_0
   - pickleshare=0.7.5=py37_1000
   - pip=19.1=py37_0
+  - pkginfo=1.5.0.1=py_0
+  - prometheus_client=0.7.0=py_0
   - prompt_toolkit=2.0.9=py_0
   - psutil=5.6.2=py37h01d97ff_0
   - ptyprocess=0.6.0=py_1001
   - py-cpuinfo=5.0.0=py_0
+  - py-lief=0.9.0=py37h6d6d4d2_1
+  - pycosat=0.6.3=py37h1de35cc_1001
   - pycparser=2.19=py37_1
   - pygments=2.4.0=py_0
+  - pynacl=1.3.0=py37h1de35cc_1000
   - pyopenssl=19.0.0=py37_0
+  - pyparsing=2.4.0=py_0
+  - pyqt=5.9.2=py37h2a560b1_0
   - pyrsistent=0.15.2=py37h01d97ff_0
   - pysocks=1.7.0=py37_0
   - python=3.7.3=h0d93f26_0
   - python-dateutil=2.8.0=py_0
+  - python-leveldb=0.194=py37h6de7cb9_1000
+  - python-libarchive-c=2.8=py37_1004
   - pytz=2019.1=py_0
   - pyyaml=5.1=py37h1de35cc_0
   - pyzmq=18.0.1=py37h2d07e9b_1
+  - qt=5.9.7=h93ee506_1
+  - qtconsole=4.5.1=py_0
   - readline=7.0=hcfe32e1_1001
   - requests=2.22.0=py37_0
   - retrying=1.3.3=py_2
   - ruamel=1.0=py37_0
   - ruamel.yaml=0.15.96=py37h01d97ff_0
+  - ruamel_yaml=0.15.71=py37h1de35cc_1000
+  - scipy=1.3.0=py37hab3da7d_0
+  - seaborn=0.9.0=py_1
+  - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py37_0
+  - sip=4.19.8=py37h0a44026_1000
   - six=1.12.0=py37_1000
+  - snappy=1.1.7=h0a44026_1002
+  - soupsieve=1.9.1=py37_0
   - sqlite=3.26.0=h1765d9f_1001
+  - sshtunnel=0.1.4=1
+  - statsmodels=0.9.0=py37h917ab60_1000
   - strictyaml=1.0.1=py_0
   - tenacity=5.0.4=py37_0
+  - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
   - textwrap3=0.9.2=py_0
   - tk=8.6.9=ha441bb4_1001
@@ -99,15 +156,15 @@ dependencies:
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py37_0
+  - widgetsnbextension=3.4.2=py37_1000
   - xz=5.2.4=h1de35cc_1001
   - yaml=0.1.7=h1de35cc_1001
   - zeromq=4.3.1=h0a44026_1000
   - zlib=1.2.11=h1de35cc_1004
+  - zstd=1.3.3=1
   - pip:
-    - configspace==0.4.10
-    - cython==0.29.7
-    - psmon==1.1.1
-    - pyparsing==2.4.0
-    - typing==3.6.6
+      - configspace==0.4.10
+      - cython==0.29.7
+      - psmon==1.1.1
+      - typing==3.6.6
 prefix: /Users/rkkautsar/.pyenv/versions/miniconda3-4.3.30/envs/reprobench
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -51,6 +51,14 @@ version = "3.9.2-r1"
 
 [[package]]
 category = "main"
+description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
+name = "asn1crypto"
+optional = false
+python-versions = "*"
+version = "0.24.0"
+
+[[package]]
+category = "main"
 description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
@@ -69,6 +77,21 @@ name = "backcall"
 optional = true
 python-versions = "*"
 version = "0.1.0"
+
+[[package]]
+category = "main"
+description = "Modern password hashing for your software and your servers"
+name = "bcrypt"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.1.6"
+
+[package.dependencies]
+cffi = ">=1.1"
+six = ">=1.4.1"
+
+[package.extras]
+tests = ["pytest (>=3.2.1,<3.3.0 || >3.3.0)"]
 
 [[package]]
 category = "main"
@@ -123,9 +146,8 @@ version = "2019.3.9"
 [[package]]
 category = "main"
 description = "Foreign Function Interface for Python calling C code."
-marker = "sys_platform == \"win32\" and platform_python_implementation == \"CPython\""
 name = "cffi"
-optional = true
+optional = false
 python-versions = "*"
 version = "1.12.3"
 
@@ -169,6 +191,26 @@ Cython = "*"
 numpy = "*"
 pyparsing = "*"
 typing = "*"
+
+[[package]]
+category = "main"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+name = "cryptography"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "2.7"
+
+[package.dependencies]
+asn1crypto = ">=0.21.0"
+cffi = ">=1.8,<1.11.3 || >1.11.3"
+six = ">=1.4.1"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0)", "sphinx-rtd-theme"]
+docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+idna = ["idna (>=2.1)"]
+pep8test = ["flake8", "flake8-import-order", "pep8-naming"]
+test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
 
 [[package]]
 category = "main"
@@ -506,6 +548,19 @@ test = ["codecov", "coverage", "notebook", "mock", "pytest (>=4.1)", "pytest-cov
 
 [[package]]
 category = "main"
+description = "SSH2 protocol library"
+name = "paramiko"
+optional = false
+python-versions = "*"
+version = "2.5.0"
+
+[package.dependencies]
+bcrypt = ">=3.1.3"
+cryptography = ">=2.5"
+pynacl = ">=1.0.1"
+
+[[package]]
+category = "main"
 description = "A Python Parser"
 name = "parso"
 optional = true
@@ -606,9 +661,8 @@ version = "5.0.0"
 [[package]]
 category = "main"
 description = "C parser in Python"
-marker = "sys_platform == \"win32\" and platform_python_implementation == \"CPython\""
 name = "pycparser"
-optional = true
+optional = false
 python-versions = "*"
 version = "2.19"
 
@@ -619,6 +673,22 @@ name = "pygments"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.4.2"
+
+[[package]]
+category = "main"
+description = "Python binding to the Networking and Cryptography (NaCl) library"
+name = "pynacl"
+optional = false
+python-versions = "*"
+version = "1.3.0"
+
+[package.dependencies]
+cffi = ">=1.4.1"
+six = "*"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+tests = ["pytest (>=3.2.1,<3.3.0 || >3.3.0)", "hypothesis (>=3.27.0)"]
 
 [[package]]
 category = "main"
@@ -722,6 +792,22 @@ name = "six"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 version = "1.12.0"
+
+[[package]]
+category = "main"
+description = "Pure python SSH tunnels"
+name = "sshtunnel"
+optional = false
+python-versions = "*"
+version = "0.1.4"
+
+[package.dependencies]
+paramiko = ">=1.15.2"
+
+[package.extras]
+build_sphinx = ["sphinx", "sphinxcontrib-napoleon"]
+dev = ["check-manifest"]
+test = ["tox (>=1.8.1)"]
 
 [[package]]
 category = "main"
@@ -854,7 +940,7 @@ server = ["pyzmq", "gevent", "peewee", "apsw", "msgpack-python"]
 sysinfo = ["psutil", "py-cpuinfo"]
 
 [metadata]
-content-hash = "6db5ba234af09fd7f6820d54901b993bb6cabe21d618f040d6b7b77840867285"
+content-hash = "8a4ba87b604391ba5c9d81aff3b75843e51eae70d62a92ecb605afdc7cdbb056"
 python-versions = ">=3.6"
 
 [metadata.hashes]
@@ -863,8 +949,10 @@ ansiwrap = ["7b053567c88e1ad9eed030d3ac41b722125e4c1271c8a99ade797faff1f49fb1", 
 appdirs = ["9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92", "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"]
 appnope = ["5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0", "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"]
 apsw = ["dab96fd164dde9e59f7f27228291498217fa0e74048e2c08c7059d7e39589270"]
+asn1crypto = ["2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87", "9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"]
 attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
 backcall = ["38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4", "bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"]
+bcrypt = ["0ba875eb67b011add6d8c5b76afbd92166e98b1f1efab9433d5dc0fafc76e203", "21ed446054c93e209434148ef0b362432bb82bbdaf7beef70a32c221f3e33d1c", "28a0459381a8021f57230954b9e9a65bb5e3d569d2c253c5cac6cb181d71cf23", "2aed3091eb6f51c26b7c2fad08d6620d1c35839e7a362f706015b41bd991125e", "2fa5d1e438958ea90eaedbf8082c2ceb1a684b4f6c75a3800c6ec1e18ebef96f", "3a73f45484e9874252002793518da060fb11eaa76c30713faa12115db17d1430", "3e489787638a36bb466cd66780e15715494b6d6905ffdbaede94440d6d8e7dba", "44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea", "678c21b2fecaa72a1eded0cf12351b153615520637efcadc09ecf81b871f1596", "75460c2c3786977ea9768d6c9d8957ba31b5fbeb0aae67a5c0e96aab4155f18c", "8ac06fb3e6aacb0a95b56eba735c0b64df49651c6ceb1ad1cf01ba75070d567f", "8fdced50a8b646fff8fa0e4b1c5fd940ecc844b43d1da5a980cb07f2d1b1132f", "9b2c5b640a2da533b0ab5f148d87fb9989bf9bcb2e61eea6a729102a6d36aef9", "a9083e7fa9adb1a4de5ac15f9097eb15b04e2c8f97618f1b881af40abce382e1", "b7e3948b8b1a81c5a99d41da5fb2dc03ddb93b5f96fcd3fd27e643f91efa33e1", "b998b8ca979d906085f6a5d84f7b5459e5e94a13fc27c28a3514437013b6c2f6", "dd08c50bc6f7be69cd7ba0769acca28c846ec46b7a8ddc2acf4b9ac6f8a7457e", "de5badee458544ab8125e63e39afeedfcf3aef6a6e2282ac159c95ae7472d773", "ede2a87333d24f55a4a7338a6ccdccf3eaa9bed081d1737e0db4dbd1a4f7e6b6"]
 better-exceptions-fork = ["5f0983da51e956dbdaf8b9a3d10e2774b382ce6c6ff2e54685c33e2dbe8f1472"]
 black = ["09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf", "68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"]
 bleach = ["213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16", "3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"]
@@ -874,6 +962,7 @@ chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "
 click = ["2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13", "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"]
 colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
 configspace = ["108204939101feabf7ca7a4c794824a82ba1d125fe0e4f8eba484a82ee5a7d96"]
+cryptography = ["24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c", "25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643", "3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216", "41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799", "5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a", "5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9", "72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc", "7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8", "961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53", "96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1", "ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609", "b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292", "cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e", "e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6", "f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed", "f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"]
 cython = ["0afa0b121b89de619e71587e25702e2b7068d7da2164c47e6eee80c17823a62f", "1c608ba76f7a20cc9f0c021b7fe5cb04bc1a70327ae93a9298b1bc3e0edddebe", "26229570d6787ff3caa932fe9d802960f51a89239b990d275ae845405ce43857", "2a9deafa437b6154cac2f25bb88e0bfd075a897c8dc847669d6f478d7e3ee6b1", "2f28396fbce6d9d68a40edbf49a6729cf9d92a4d39ff0f501947a89188e9099f", "3983dd7b67297db299b403b29b328d9e03e14c4c590ea90aa1ad1d7b35fb178b", "4100a3f8e8bbe47d499cdac00e56d5fe750f739701ea52dc049b6c56f5421d97", "51abfaa7b6c66f3f18028876713c8804e73d4c2b6ceddbcbcfa8ec62429377f0", "61c24f4554efdb8fb1ac6c8e75dab301bcdf2b7b739ed0c2b267493bb43163c5", "700ccf921b2fdc9b23910e95b5caae4b35767685e0812343fa7172409f1b5830", "7b41eb2e792822a790cb2a171df49d1a9e0baaa8e81f58077b7380a273b93d5f", "803987d3b16d55faa997bfc12e8b97f1091f145930dee229b020487aed8a1f44", "99af5cfcd208c81998dcf44b3ca466dee7e17453cfb50e98b87947c3a86f8753", "9faea1cca34501c7e139bc7ef8e504d532b77865c58592493e2c154a003b450f", "a7ba4c9a174db841cfee9a0b92563862a0301d7ca543334666c7266b541f141a", "b26071c2313d1880599c69fd831a07b32a8c961ba69d7ccbe5db1cd8d319a4ca", "b49dc8e1116abde13a3e6a9eb8da6ab292c5a3325155fb872e39011b110b37e6", "bd40def0fd013569887008baa6da9ca428e3d7247adeeaeada153006227bb2e7", "bfd0db770e8bd4e044e20298dcae6dfc42561f85d17ee546dcd978c8b23066ae", "c2fad1efae5889925c8fd7867fdd61f59480e4e0b510f9db096c912e884704f1", "c81aea93d526ccf6bc0b842c91216ee9867cd8792f6725a00f19c8b5837e1715", "da786e039b4ad2bce3d53d4799438cf1f5e01a0108f1b8d78ac08e6627281b1a", "deab85a069397540987082d251e9c89e0e5b2e3e044014344ff81f60e211fc4b", "e3f1e6224c3407beb1849bdc5ae3150929e593e4cffff6ca41c6ec2b10942c80", "e74eb224e53aae3943d66e2d29fe42322d5753fd4c0641329bccb7efb3a46552", "ee697c7ea65cb14915a64f36874da8ffc2123df43cf8bc952172e04a26656cd6", "f37792b16d11606c28e428460bd6a3d14b8917b109e77cdbe4ca78b0b9a52c87", "fd2906b54cbf879c09d875ad4e4687c58d87f5ed03496063fec1c9065569fd5d"]
 decorator = ["86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de", "f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"]
 defusedxml = ["6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93", "f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"]
@@ -899,6 +988,7 @@ numpy = ["0778076e764e146d3078b17c24c4d89e0ecd4ac5401beff8e1c87879043a0633", "14
 pandas = ["071e42b89b57baa17031af8c6b6bbd2e9a5c68c595bc6bf9adabd7a9ed125d3b", "17450e25ae69e2e6b303817bdf26b2cd57f69595d8550a77c308be0cd0fd58fa", "17916d818592c9ec891cbef2e90f98cc85e0f1e89ed0924c9b5220dc3209c846", "2538f099ab0e9f9c9d09bbcd94b47fd889bad06dc7ae96b1ed583f1dc1a7a822", "366f30710172cb45a6b4f43b66c220653b1ea50303fbbd94e50571637ffb9167", "42e5ad741a0d09232efbc7fc648226ed93306551772fc8aecc6dce9f0e676794", "4e718e7f395ba5bfe8b6f6aaf2ff1c65a09bb77a36af6394621434e7cc813204", "4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2", "4fe0d7e6438212e839fc5010c78b822664f1a824c0d263fd858f44131d9166e2", "5149a6db3e74f23dc3f5a216c2c9ae2e12920aa2d4a5b77e44e5b804a5f93248", "627594338d6dd995cfc0bacd8e654cd9e1252d2a7c959449228df6740d737eb8", "83c702615052f2a0a7fb1dd289726e29ec87a27272d775cb77affe749cca28f8", "8c872f7fdf3018b7891e1e3e86c55b190e6c5cee70cab771e8f246c855001296", "90f116086063934afd51e61a802a943826d2aac572b2f7d55caaac51c13db5b5", "a3352bacac12e1fc646213b998bce586f965c9d431773d9e91db27c7c48a1f7d", "bcdd06007cca02d51350f96debe51331dec429ac8f93930a43eb8fb5639e3eb5", "c1bd07ebc15285535f61ddd8c0c75d0d6293e80e1ee6d9a8d73f3f36954342d0", "c9a4b7c55115eb278c19aa14b34fcf5920c8fe7797a09b7b053ddd6195ea89b3", "cc8fc0c7a8d5951dc738f1c1447f71c43734244453616f32b8aa0ef6013a5dfb", "d7b460bc316064540ce0c41c1438c416a40746fd8a4fb2999668bf18f3c4acf1"]
 pandocfilters = ["b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9"]
 papermill = ["1c565e1fe7a99aeb5c4ebe1035d2c8f17c10999256df85bd427160154ca86d2f", "e9a2b532550bb92fc72d048a1a6125fa0ab6c2b3fde27a8ccfb1981cf074ed2c"]
+paramiko = ["69c219df239775800a2589ee60159aa7cfd87175809b6557da7fb9dcb44ca430", "9f081281064b5180dc0ef60e256224a280ff16f603a99f3dd4ba6334ebb65f7e"]
 parso = ["17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33", "2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376"]
 pathspec = ["54a5eab895d89f342b52ba2bffe70930ef9f8d96e398cccf530d21fa0516a873"]
 peewee = ["bc879e1ffb7f7684f90d9dd236c77b5042118d079f94764f35e3806948829ac8"]
@@ -911,6 +1001,7 @@ ptyprocess = ["923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"
 py-cpuinfo = ["2cf6426f776625b21d1db8397d3297ef7acfa59018f02a8779123f3190f18500"]
 pycparser = ["a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"]
 pygments = ["71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127", "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"]
+pynacl = ["05c26f93964373fc0abe332676cb6735f0ecad27711035b9472751faa8521255", "0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c", "0d0a8171a68edf51add1e73d2159c4bc19fc0718e79dec51166e940856c2f28e", "1c780712b206317a746ace34c209b8c29dbfd841dfbc02aa27f2084dd3db77ae", "2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621", "2d23c04e8d709444220557ae48ed01f3f1086439f12dbf11976e849a4926db56", "30f36a9c70450c7878053fa1344aca0145fd47d845270b43a7ee9192a051bf39", "37aa336a317209f1bb099ad177fef0da45be36a2aa664507c5d72015f956c310", "4943decfc5b905748f0756fdd99d4f9498d7064815c4cf3643820c9028b711d1", "57ef38a65056e7800859e5ba9e6091053cd06e1038983016effaffe0efcd594a", "5bd61e9b44c543016ce1f6aef48606280e45f892a928ca7068fba30021e9b786", "6482d3017a0c0327a49dddc8bd1074cc730d45db2ccb09c3bac1f8f32d1eb61b", "7d3ce02c0784b7cbcc771a2da6ea51f87e8716004512493a2b69016326301c3b", "a14e499c0f5955dcc3991f785f3f8e2130ed504fa3a7f44009ff458ad6bdd17f", "a39f54ccbcd2757d1d63b0ec00a00980c0b382c62865b61a505163943624ab20", "aabb0c5232910a20eec8563503c153a8e78bbf5459490c49ab31f6adf3f3a415", "bd4ecb473a96ad0f90c20acba4f0bf0df91a4e03a1f4dd6a4bdc9ca75aa3a715", "e2da3c13307eac601f3de04887624939aca8ee3c9488a0bb0eca4fb9401fc6b1", "f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"]
 pyparsing = ["1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a", "9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"]
 pyrsistent = ["16692ee739d42cf5e39cef8d27649a8c1fdb7aa99887098f1460057c5eb75c3a"]
 python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
@@ -921,6 +1012,7 @@ requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", 
 retrying = ["08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"]
 "ruamel.yaml" = ["17dbf6b7362e7aee8494f7a0f5cffd44902a6331fe89ef0853b855a7930ab845", "23731c9efb79f3f5609dedffeb6c5c47a68125fd3d4b157d9fc71b1cd49076a9", "2bbdd598ae57bac20968cf9028cc67d37d83bdb7942a94b9478110bc72193148", "34586084cdd60845a3e1bece2b58f0a889be25450db8cc0ea143ddf0f40557a2", "35957fedbb287b01313bb5c556ffdc70c0277c3500213b5e73dfd8716f748d77", "414cb87a40974a575830b406ffab4ab8c6cbd82eeb73abd2a9d1397c1f0223e1", "428775be75db68d908b17e4e8dda424c410222f170dc173246aa63e972d094b3", "514f670f7d36519bda504d507edfe63e3c20489f86c86d42bc4d9a6dbdf82c7b", "5cb962c1ac6887c5da29138fbbe3b4b7705372eb54e599907fa63d4cd743246d", "5f6e30282cf70fb7754e1a5f101e27b5240009766376e131b31ab49f14fe81be", "86f8e010af6af0b4f42de2d0d9b19cb441e61d3416082186f9dd03c8552d13ad", "8d47ed1e557d546bd2dfe54f504d7274274602ff7a0652cde84c258ad6c2d96d", "98668876720bce1ac08562d8b93a564a80e3397e442c7ea19cebdcdf73da7f74", "9e1f0ddc18d8355dcf5586a5d90417df56074f237812b8682a93b62cca9d2043", "a7bc812a72a79d6b7dbb96fa5bee3950464b65ec055d3abc4db6572f2373a95c", "b72e13f9f206ee103247b07afd5a39c8b1aa98e8eba80ddba184d030337220ba", "bcff8ea9d916789e85e24beed8830c157fb8bc7c313e554733a8151540e66c01", "c76e78b3bab652069b8d6f7889b0e72f3455c2b854b2e0a8818393d149ad0a0d"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
+sshtunnel = ["f29ae41a1bd3afa64e9a31029bece2966e4be9a9641e8262372741e691c40d76"]
 strictyaml = ["06d7100587695a0edfabd772a6c6fb69071fc38c413df599e22dfd40e52f5fad"]
 tenacity = ["a0c3c5f7ae0c33f5556c775ca059c12d6fd8ab7121613a713e8b7d649908571b", "b87c1934daa0b2ccc7db153c37b8bf91d12f165936ade8628e7b962b92dc7705"]
 testpath = ["46c89ebb683f473ffe2aab0ed9f12581d4d078308a3cb3765d79c6b2317b0109", "b694b3d9288dbd81685c5d2e7140b81365d46c29f5db4bc659de5aa6b98780f8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reprobench"
-version = "0.11.0.dev4"
+version = "0.11.0.dev14"
 readme = "README.md"
 description = "Reproducible Benchmark for Everyone"
 authors = ["Rakha Kanz Kautsar <rkkautsar@gmail.com>"]
@@ -27,6 +27,7 @@ configspace = { version = "^0.4.10", optional = true }
 pandas = { version = "^0.24.2", optional = true }
 papermill = { version = ">=0.19.1,<1.1.0", optional = true }
 retrying = "^1.3"
+sshtunnel = "^0.1.4"
 
 [tool.poetry.extras]
 sysinfo = ["psutil", "py-cpuinfo"]

--- a/reprobench/core/bootstrap/server.py
+++ b/reprobench/core/bootstrap/server.py
@@ -138,13 +138,12 @@ def create_parameter_group(tool, group, parameters):
     }
 
     if len(ranged_parameters) == 0:
-        parameter_group = (
-            ParameterGroup.insert(name=group, tool=tool).on_conflict("ignore").execute()
-        )
+        parameter_group, _ = ParameterGroup.get_or_create(name=group, tool=tool)
+
         for (key, value) in parameters.items():
             query = Parameter.insert(
                 group=parameter_group, key=key, value=value
-            ).on_conflict("ignore")
+            ).on_conflict("replace")
             query.execute()
         return
 
@@ -163,10 +162,9 @@ def create_parameter_group(tool, group, parameters):
             check_valid_config_space(config_space, parameters)
 
         combination_str = ",".join(f"{key}={value}" for key, value in combination)
-        query = ParameterGroup.insert(
-            name=f"{group}[{combination_str}]", tool=tool
-        ).on_conflict("ignore")
-        parameter_group = query.execute()
+        group_name = f"{group}[{combination_str}]"
+
+        parameter_group, _ = ParameterGroup.get_or_create(name=group_name, tool=tool)
 
         for (key, value) in parameters.items():
             query = Parameter.insert(

--- a/reprobench/core/worker.py
+++ b/reprobench/core/worker.py
@@ -1,12 +1,14 @@
+import sys
 import atexit
 import json
 from pathlib import Path
 
 import click
 import zmq
+from sshtunnel import SSHTunnelForwarder
 from loguru import logger
 
-from reprobench.console.decorators import common, server_info
+from reprobench.console.decorators import common, server_info, use_tunneling
 from reprobench.core.events import (
     RUN_FINISH,
     RUN_INTERRUPT,
@@ -21,23 +23,46 @@ REQUEST_TIMEOUT = 15000
 
 
 class BenchmarkWorker:
-    def __init__(self, server_address, run_id):
+    def __init__(self, server_address, tunneling):
         self.server_address = server_address
-        self.run_id = run_id
+
+        if tunneling is not None:
+            self.server = SSHTunnelForwarder(
+                tunneling["host"],
+                remote_bind_address=("127.0.0.1", tunneling["port"]),
+                ssh_pkey=tunneling["key_file"],
+                ssh_config_file=tunneling["ssh_config_file"],
+            )
+
+            # https://github.com/pahaz/sshtunnel/issues/138
+            if sys.version_info[0] > 3 or (
+                sys.version_info[0] == 3 and sys.version_info[1] >= 7
+            ):
+                self.server.daemon_forward_servers = True
+
+            self.server.start()
+            self.server_address = f"tcp://127.0.0.1:{self.server.local_bind_port}"
+            logger.info(f"Tunneling established at {self.server_address}")
+            atexit.register(self.stop_tunneling)
 
     def killed(self, run_id):
         send_event(self.socket, RUN_INTERRUPT, run_id)
         send_event(self.socket, WORKER_LEAVE)
 
-    def run(self):
-        atexit.register(self.killed, self.run_id)
+    def stop_tunneling(self):
+        self.server.stop()
 
+    def run(self):
         context = zmq.Context()
         self.socket = context.socket(zmq.DEALER)
+        logger.debug(f"Connecting to {self.server_address}")
         self.socket.connect(self.server_address)
 
-        send_event(self.socket, WORKER_JOIN, self.run_id)
+        send_event(self.socket, WORKER_JOIN)
         run = decode_message(self.socket.recv())
+
+        self.run_id = run["id"]
+        atexit.register(self.killed, self.run_id)
 
         tool = import_class(run["tool"])
 
@@ -70,11 +95,11 @@ class BenchmarkWorker:
 
 
 @click.command("worker")
-@click.argument("run_id")
-@common
 @server_info
-def cli(server_address, run_id):
-    worker = BenchmarkWorker(server_address, run_id)
+@use_tunneling
+@common
+def cli(**kwargs):
+    worker = BenchmarkWorker(**kwargs)
     worker.run()
 
 

--- a/reprobench/managers/local/__init__.py
+++ b/reprobench/managers/local/__init__.py
@@ -3,7 +3,7 @@ from multiprocessing import cpu_count
 import click
 from loguru import logger
 
-from reprobench.console.decorators import server_info, common
+from reprobench.console.decorators import server_info, common, use_tunneling
 
 from .manager import LocalManager
 
@@ -17,6 +17,7 @@ from .manager import LocalManager
 @click.argument("command", type=click.Choice(("run",)))
 @click.argument("config", type=click.Path(), default="./benchmark.yml")
 @server_info
+@use_tunneling
 @common
 def cli(command, **kwargs):
     manager = LocalManager(**kwargs)

--- a/reprobench/managers/local/manager.py
+++ b/reprobench/managers/local/manager.py
@@ -1,7 +1,9 @@
 import atexit
 import time
+import sys
 from multiprocessing import Pool
 
+from sshtunnel import SSHTunnelForwarder
 from loguru import logger
 from tqdm import tqdm
 
@@ -26,22 +28,41 @@ class LocalManager(BaseManager):
     def prepare(self):
         atexit.register(self.exit)
         self.start_time = time.perf_counter()
+        if self.tunneling is not None:
+            self.server = SSHTunnelForwarder(
+                self.tunneling["host"],
+                remote_bind_address=("127.0.0.1", self.tunneling["port"]),
+                ssh_pkey=self.tunneling["key_file"],
+                ssh_config_file=self.tunneling["ssh_config_file"],
+            )
+
+            # https://github.com/pahaz/sshtunnel/issues/138
+            if sys.version_info[0] > 3 or (
+                sys.version_info[0] == 3 and sys.version_info[1] >= 7
+            ):
+                self.server.daemon_forward_servers = True
+
+            self.server.start()
+            self.server_address = f"tcp://127.0.0.1:{self.server.local_bind_port}"
+            logger.info(f"Tunneling established at {self.server_address}")
 
     @staticmethod
-    def spawn_worker(job):
-        server_address, run_id = job
-        worker = BenchmarkWorker(server_address, run_id)
+    def spawn_worker(server_address):
+        worker = BenchmarkWorker(server_address)
         worker.run()
 
     def spawn_workers(self):
         self.pool = Pool(self.num_workers)
-        jobs = ((self.server_address, run_id) for run_id in self.queue)
+        jobs = (self.server_address for _ in range(self.pending))
         self.pool_iterator = self.pool.imap_unordered(self.spawn_worker, jobs)
         self.pool.close()
 
     def wait(self):
-        progress_bar = tqdm(desc="Executing runs", total=len(self.queue))
+        progress_bar = tqdm(desc="Executing runs", total=self.pending)
         for _ in self.pool_iterator:
             progress_bar.update()
         progress_bar.close()
         self.pool.join()
+
+        if self.tunneling is not None:
+            self.server.stop()

--- a/reprobench/managers/slurm/__init__.py
+++ b/reprobench/managers/slurm/__init__.py
@@ -1,6 +1,6 @@
 import click
 
-from reprobench.console.decorators import common, server_info
+from reprobench.console.decorators import common, server_info, use_tunneling
 from reprobench.utils import read_config
 
 from .manager import SlurmManager
@@ -14,6 +14,7 @@ from .manager import SlurmManager
 @click.argument("command", type=click.Choice(("run", "stop")))
 @click.argument("config", type=click.Path(), default="./benchmark.yml")
 @server_info
+@use_tunneling
 @common
 def cli(command, **kwargs):
     manager = SlurmManager(**kwargs)

--- a/reprobench/managers/slurm/manager.py
+++ b/reprobench/managers/slurm/manager.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from sshtunnel import SSHTunnelForwarder
 from reprobench.managers.base import BaseManager
 from reprobench.utils import read_config
 
@@ -22,24 +23,52 @@ class SlurmManager(BaseManager):
         self.time_limit = 2 * time_limit_minutes
         self.mem_limit = 2 * limits["memory"]
 
+        if self.tunneling is not None:
+            self.server = SSHTunnelForwarder(
+                self.tunneling["host"],
+                remote_bind_address=("127.0.0.1", self.tunneling["port"]),
+                ssh_pkey=self.tunneling["key_file"],
+                ssh_config_file=self.tunneling["ssh_config_file"],
+            )
+
+            # https://github.com/pahaz/sshtunnel/issues/138
+            if sys.version_info[0] > 3 or (
+                sys.version_info[0] == 3 and sys.version_info[1] >= 7
+            ):
+                self.server.daemon_forward_servers = True
+
+            self.server.start()
+            self.server_address = f"tcp://127.0.0.1:{self.server.local_bind_port}"
+            logger.info(f"Tunneling established at {self.server_address}")
+
     def stop(self):
         subprocess.run(["scancel", f"--name={self.config['title']}-benchmark-worker"])
 
     def spawn_workers(self):
         logger.info("Spawning workers...")
-        worker_cmd = f"{sys.exec_prefix}/bin/reprobench worker --address={self.server_address} -vv"
+
+        address_args = f"--address={self.server_address}"
+        if self.tunneling is not None:
+            address_args = f"-h {self.tunneling['host']} -p {self.tunneling['port']} -K {self.tunneling['key_file']}"
+
+        worker_cmd = f"{sys.exec_prefix}/bin/reprobench worker {address_args} -vv"
         worker_submit_cmd = [
             "sbatch",
             "--parsable",
-            f"--array={to_comma_range(self.queue)}",
+            f"--array=1-{self.pending}",
             f"--time={self.time_limit}",
             f"--mem={self.mem_limit}",
             f"--cpus-per-task={self.cpu_count}",
             f"--job-name={self.config['title']}-benchmark-worker",
             f"--output={self.output_dir}/slurm-worker_%a.out",
             "--wrap",
-            f"srun {worker_cmd} $SLURM_ARRAY_TASK_ID",
+            f"srun {worker_cmd}",
         ]
         logger.trace(worker_submit_cmd)
         self.worker_job = subprocess.check_output(worker_submit_cmd).decode().strip()
         logger.info(f"Worker job array id: {self.worker_job}")
+
+    def wait(self):
+        if self.tunneling is not None:
+            self.server.stop()
+


### PR DESCRIPTION
Closes #39 
Closes #40 

SSH Tunneling is still buggy. The connection hangs and can't be stopped, related: https://github.com/pahaz/sshtunnel/issues/138

Might be better to implement a robust custom end-to-end encryption instead. It will reduce SSH connection overhead and the need to open many ports.